### PR TITLE
Python 3.7: fix building pyquante2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # cclib-ci
-cclib ci docker images
+
+cclib CI Docker images
 
 Building the images:
- 1. `cd path to py3*`
- 2. `sudo docker build -t shivupa/cclib-ci . | tee buildlog.txt`
- 3. `sudo docker image ls` (get the build hash of the latest image
- 4. `sudo docker tag BUILDHASH shivupa/cclib-ci:py37`
- 5. `sudo docker push shivupa/cclib-ci:py37`
+
+1. `cd path to py3*`
+2. `sudo docker buildx build -t shivupa/cclib-ci:py37 . | tee buildlog.txt`
+3. `sudo docker image ls` (get the build hash of the latest image
+4. `sudo docker tag BUILDHASH shivupa/cclib-ci:py37`
+5. `sudo docker push shivupa/cclib-ci:py37`
+
+You may need to install https://github.com/docker/buildx first.

--- a/py37/Dockerfile
+++ b/py37/Dockerfile
@@ -10,15 +10,14 @@ RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create -f /tmp/environme
 
 RUN apt-get update && \
     apt-get install -y -qq --no-install-recommends \
+      build-essential \
       curl \
       gcc \
       git \
       swig \
-      wget \
     && rm -rf /var/lib/apt/lists/*
-RUN wget \
-    https://raw.githubusercontent.com/cclib/cclib/master/requirements.txt \
-    && cat requirements.txt
+RUN curl -o requirements.txt \
+    https://raw.githubusercontent.com/berquist/cclib/pyquante2/requirements.txt
 RUN conda run -p /env python -m pip install -r requirements.txt
 
 RUN rm -f /tmp/environment.yml && \


### PR DESCRIPTION
Part 2 of #8.

- Fixes for building pyquante2 with this Python version are at https://github.com/berquist/pyquante2/tree/py37
- Installing this branch as a dependency is done in https://github.com/berquist/cclib/blob/0a4b4be4d4a097ee27a7268d6b24c3a968d622ff/requirements.txt#L11
- In order to do the build, GCC was missing core libraries/headers, so added `build-essential`