### PR TITLE
clone and test images against latest cclib at image build time

### DIFF
--- a/.github/workflows/py310.yaml
+++ b/.github/workflows/py310.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+  schedule:
+    - cron: '0 11 * * 2'
 
 jobs:
   docker:
@@ -13,11 +15,32 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: Gather metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            shivupa/cclib-ci
+          flavor: |
+            latest=true
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}},prefix=py310-
+            type=sha,prefix=py310-
+            type=edge,prefix=py310-
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      -
+        name: Build and export to Docker
+        uses: docker/build-push-action@v3
+        with:
+          context: py310
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v2
@@ -30,4 +53,4 @@ jobs:
         with:
           context: py310
           push: true
-          tags: shivupa/cclib-ci:py310
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/py37.yaml
+++ b/.github/workflows/py37.yaml
@@ -34,6 +34,14 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
+        name: Build and export to Docker
+        uses: docker/build-push-action@v3
+        with:
+          context: py37
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+      -
         name: Login to DockerHub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/py38.yaml
+++ b/.github/workflows/py38.yaml
@@ -15,11 +15,32 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: Gather metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            shivupa/cclib-ci
+          flavor: |
+            latest=true
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}},prefix=py38-
+            type=sha,prefix=py38-
+            type=edge,prefix=py38-
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      -
+        name: Build and export to Docker
+        uses: docker/build-push-action@v3
+        with:
+          context: py38
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v2
@@ -32,4 +53,4 @@ jobs:
         with:
           context: py38
           push: true
-          tags: shivupa/cclib-ci:py38
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/py39.yaml
+++ b/.github/workflows/py39.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+  schedule:
+    - cron: '0 11 * * 2'
 
 jobs:
   docker:
@@ -13,11 +15,32 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: Gather metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            shivupa/cclib-ci
+          flavor: |
+            latest=true
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}},prefix=py39-
+            type=sha,prefix=py39-
+            type=edge,prefix=py39-
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      -
+        name: Build and export to Docker
+        uses: docker/build-push-action@v3
+        with:
+          context: py39
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v2
@@ -30,4 +53,4 @@ jobs:
         with:
           context: py39
           push: true
-          tags: shivupa/cclib-ci:py39
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.secrets

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,17 @@
+dir := invocation_directory()
+tag := file_name(dir)
+
+# These commands are meant to be executed from within each directory
+# containing a Dockerfile.
+#
+# If your user is not a part of the `docker` group and needs elevated
+# permissions to execute Docker commands, `sudo just ...` is sufficient.
+
+build:
+    docker buildx build -t shivupa/cclib-ci:{{ tag }} {{ dir }}
+
+shell:
+    docker run -it shivupa/cclib-ci:{{ tag }} bash
+
+act:
+    act -W ./.github/workflows/{{ tag }}.yaml -P ubuntu-latest=catthehacker/ubuntu:act-latest

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Building the images:
 5. `sudo docker push shivupa/cclib-ci:py37`
 
 You may need to install https://github.com/docker/buildx first.
+
+## Running with https://github.com/nektos/act
+
+Your `.secrets` file (in `.env` format, just like setting a local variable in a `sh` shell script) must contain `GITHUB_TOKEN` for the Docker metadata action to work.  It is a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) that only needs repository read permissions to work.  If using a "fine-grained" token, no additional permissions beyond the defaults are necessary.

--- a/py310/Dockerfile
+++ b/py310/Dockerfile
@@ -1,34 +1,39 @@
-FROM condaforge/mambaforge:latest as conda
+FROM condaforge/mambaforge:22.9.0-2@sha256:a508942c46f370f2bebd94801d6094d0d5be77c4f36ad0edd608b118998fbca8 as install
 
-LABEL authors="Shiv Upadhyay <shivnupadhyay@gmail.com>, Eric Berquist <eric.berquist@gmail.com>"
+LABEL org.opencontainers.image.authors="Shiv Upadhyay <shivnupadhyay@gmail.com>, Eric Berquist <eric.berquist@gmail.com>"
 
-COPY ./condarc /root/.condarc
-COPY ./environment.yml /tmp/
+SHELL ["/bin/bash", "-l", "-i", "-c"]
+ENV SHELL /bin/bash
+
+ENV HOME /root
+WORKDIR "$HOME"
+
+COPY ./condarc "$HOME"/.condarc
+COPY ./environment.yml .
 
 RUN mamba info -a
-RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create -f /tmp/environment.yml -p /env
+RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create --file="$HOME"/environment.yml --name=cclib
 
 RUN apt-get update && \
-    apt-get install -y -qq \
+    apt-get install -y -qq --no-install-recommends \
+      build-essential \
       curl \
       gcc \
       git \
       swig \
-      wget
-RUN wget \
-    https://raw.githubusercontent.com/cclib/cclib/master/requirements.txt \
-    && cat requirements.txt
-RUN conda run -p /env python -m pip install -r requirements.txt
+    && rm -rf /var/lib/apt/lists/*
+RUN mamba init && \
+    echo "mamba activate cclib" >> "$HOME"/.bashrc && \
+    curl -o requirements.txt \
+    https://raw.githubusercontent.com/berquist/cclib/pyquante2/requirements.txt && \
+    mamba run -n cclib python -m pip install --no-cache-dir -r requirements.txt
 
-RUN rm -f /tmp/environment.yml
-RUN rm -f requirements.txt
-RUN rm -rf /root/.cache/pip
-RUN rm -rf /var/lib/apt/lists/*
+FROM install as test
 
-RUN rm -f /env/bin/perl
-RUN rm -f /env/bin/perl5.30.0
-RUN rm -rf /env/conda-meta
-RUN rm -rf /env/share/man
-RUN rm -rf /env/share/terminfo
-RUN find /env -name '__pycache__' -type d -exec rm -rf '{}' '+'
-RUN find /env -name '*.a' -type f -exec rm -f '{}' '+'
+SHELL ["/bin/bash", "-l", "-i", "-c"]
+WORKDIR "$HOME"
+RUN git clone https://github.com/cclib/cclib.git
+WORKDIR "$HOME"/cclib
+COPY test.bash .
+RUN ./test.bash
+WORKDIR "$HOME"

--- a/py310/environment.yml
+++ b/py310/environment.yml
@@ -4,7 +4,8 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - h5py=2.10
+  - cython  # only needed for pyquante2
+  - h5py
   - openbabel
   - pip
   - psi4

--- a/py310/test.bash
+++ b/py310/test.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S bash --login
+
+set -euo pipefail
+set -x
+
+bash ./.github/scripts/run_pytest.bash
+bash ./.github/scripts/run_pytest_methods.bash
+
+set +x

--- a/py37/Dockerfile
+++ b/py37/Dockerfile
@@ -1,12 +1,18 @@
-FROM condaforge/mambaforge:4.11.0-4 as conda
+FROM condaforge/mambaforge:22.9.0-2@sha256:a508942c46f370f2bebd94801d6094d0d5be77c4f36ad0edd608b118998fbca8 as install
 
-LABEL authors="Shiv Upadhyay <shivnupadhyay@gmail.com>, Eric Berquist <eric.berquist@gmail.com>"
+LABEL org.opencontainers.image.authors="Shiv Upadhyay <shivnupadhyay@gmail.com>, Eric Berquist <eric.berquist@gmail.com>"
 
-COPY ./condarc /root/.condarc
-COPY ./environment.yml /tmp/
+SHELL ["/bin/bash", "-l", "-i", "-c"]
+ENV SHELL /bin/bash
+
+ENV HOME /root
+WORKDIR "$HOME"
+
+COPY ./condarc "$HOME"/.condarc
+COPY ./environment.yml .
 
 RUN mamba info -a
-RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create -f /tmp/environment.yml -p /env
+RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create --file="$HOME"/environment.yml --name=cclib
 
 RUN apt-get update && \
     apt-get install -y -qq --no-install-recommends \
@@ -16,17 +22,18 @@ RUN apt-get update && \
       git \
       swig \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -o requirements.txt \
-    https://raw.githubusercontent.com/berquist/cclib/pyquante2/requirements.txt
-RUN conda run -p /env python -m pip install -r requirements.txt
+RUN mamba init && \
+    echo "mamba activate cclib" >> "$HOME"/.bashrc && \
+    curl -o requirements.txt \
+    https://raw.githubusercontent.com/berquist/cclib/pyquante2/requirements.txt && \
+    mamba run -n cclib python -m pip install --no-cache-dir -r requirements.txt
 
-RUN rm -f /tmp/environment.yml && \
-    rm -f requirements.txt && \
-    rm -rf /root/.cache/pip && \
-    rm -f /env/bin/perl && \
-    rm -f /env/bin/perl5.30.0 && \
-    rm -rf /env/conda-meta && \
-    rm -rf /env/share/man && \
-    rm -rf /env/share/terminfo && \
-    find /env -name '__pycache__' -type d -exec rm -rf '{}' '+' && \
-    find /env -name '*.a' -type f -exec rm -f '{}' '+'
+FROM install as test
+
+SHELL ["/bin/bash", "-l", "-i", "-c"]
+WORKDIR "$HOME"
+RUN git clone https://github.com/cclib/cclib.git
+WORKDIR "$HOME"/cclib
+COPY test.bash .
+RUN ./test.bash
+WORKDIR "$HOME"

--- a/py37/test.bash
+++ b/py37/test.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S bash --login
+
+set -euo pipefail
+set -x
+
+bash ./.github/scripts/run_pytest.bash
+bash ./.github/scripts/run_pytest_methods.bash
+
+set +x

--- a/py38/Dockerfile
+++ b/py38/Dockerfile
@@ -1,34 +1,39 @@
-FROM condaforge/mambaforge:latest as conda
+FROM condaforge/mambaforge:22.9.0-2@sha256:a508942c46f370f2bebd94801d6094d0d5be77c4f36ad0edd608b118998fbca8 as install
 
-LABEL authors="Shiv Upadhyay <shivnupadhyay@gmail.com>, Eric Berquist <eric.berquist@gmail.com>"
+LABEL org.opencontainers.image.authors="Shiv Upadhyay <shivnupadhyay@gmail.com>, Eric Berquist <eric.berquist@gmail.com>"
 
-COPY ./condarc /root/.condarc
-COPY ./environment.yml /tmp/
+SHELL ["/bin/bash", "-l", "-i", "-c"]
+ENV SHELL /bin/bash
+
+ENV HOME /root
+WORKDIR "$HOME"
+
+COPY ./condarc "$HOME"/.condarc
+COPY ./environment.yml .
 
 RUN mamba info -a
-RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create -f /tmp/environment.yml -p /env
+RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create --file="$HOME"/environment.yml --name=cclib
 
 RUN apt-get update && \
-    apt-get install -y -qq \
+    apt-get install -y -qq --no-install-recommends \
+      build-essential \
       curl \
       gcc \
       git \
       swig \
-      wget
-RUN wget \
-    https://raw.githubusercontent.com/cclib/cclib/master/requirements.txt \
-    && cat requirements.txt
-RUN conda run -p /env python -m pip install -r requirements.txt
+    && rm -rf /var/lib/apt/lists/*
+RUN mamba init && \
+    echo "mamba activate cclib" >> "$HOME"/.bashrc && \
+    curl -o requirements.txt \
+    https://raw.githubusercontent.com/berquist/cclib/pyquante2/requirements.txt && \
+    mamba run -n cclib python -m pip install --no-cache-dir -r requirements.txt
 
-RUN rm -f /tmp/environment.yml
-RUN rm -f requirements.txt
-RUN rm -rf /root/.cache/pip
-RUN rm -rf /var/lib/apt/lists/*
+FROM install as test
 
-RUN rm -f /env/bin/perl
-RUN rm -f /env/bin/perl5.30.0
-RUN rm -rf /env/conda-meta
-RUN rm -rf /env/share/man
-RUN rm -rf /env/share/terminfo
-RUN find /env -name '__pycache__' -type d -exec rm -rf '{}' '+'
-RUN find /env -name '*.a' -type f -exec rm -f '{}' '+'
+SHELL ["/bin/bash", "-l", "-i", "-c"]
+WORKDIR "$HOME"
+RUN git clone https://github.com/cclib/cclib.git
+WORKDIR "$HOME"/cclib
+COPY test.bash .
+RUN ./test.bash
+WORKDIR "$HOME"

--- a/py38/environment.yml
+++ b/py38/environment.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - cython  # only needed for pyquante2
   - h5py=2.10
   - openbabel
   - pip

--- a/py38/test.bash
+++ b/py38/test.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S bash --login
+
+set -euo pipefail
+set -x
+
+bash ./.github/scripts/run_pytest.bash
+bash ./.github/scripts/run_pytest_methods.bash
+
+set +x

--- a/py39/Dockerfile
+++ b/py39/Dockerfile
@@ -1,34 +1,39 @@
-FROM condaforge/mambaforge:latest as conda
+FROM condaforge/mambaforge:22.9.0-2@sha256:a508942c46f370f2bebd94801d6094d0d5be77c4f36ad0edd608b118998fbca8 as install
 
-LABEL authors="Shiv Upadhyay <shivnupadhyay@gmail.com>, Eric Berquist <eric.berquist@gmail.com>"
+LABEL org.opencontainers.image.authors="Shiv Upadhyay <shivnupadhyay@gmail.com>, Eric Berquist <eric.berquist@gmail.com>"
 
-COPY ./condarc /root/.condarc
-COPY ./environment.yml /tmp/
+SHELL ["/bin/bash", "-l", "-i", "-c"]
+ENV SHELL /bin/bash
+
+ENV HOME /root
+WORKDIR "$HOME"
+
+COPY ./condarc "$HOME"/.condarc
+COPY ./environment.yml .
 
 RUN mamba info -a
-RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create -f /tmp/environment.yml -p /env
+RUN --mount=type=cache,target=/opt/conda/pkgs mamba env create --file="$HOME"/environment.yml --name=cclib
 
 RUN apt-get update && \
-    apt-get install -y -qq \
+    apt-get install -y -qq --no-install-recommends \
+      build-essential \
       curl \
       gcc \
       git \
       swig \
-      wget
-RUN wget \
-    https://raw.githubusercontent.com/cclib/cclib/master/requirements.txt \
-    && cat requirements.txt
-RUN conda run -p /env python -m pip install -r requirements.txt
+    && rm -rf /var/lib/apt/lists/*
+RUN mamba init && \
+    echo "mamba activate cclib" >> "$HOME"/.bashrc && \
+    curl -o requirements.txt \
+    https://raw.githubusercontent.com/berquist/cclib/pyquante2/requirements.txt && \
+    mamba run -n cclib python -m pip install --no-cache-dir -r requirements.txt
 
-RUN rm -f /tmp/environment.yml
-RUN rm -f requirements.txt
-RUN rm -rf /root/.cache/pip
-RUN rm -rf /var/lib/apt/lists/*
+FROM install as test
 
-RUN rm -f /env/bin/perl
-RUN rm -f /env/bin/perl5.30.0
-RUN rm -rf /env/conda-meta
-RUN rm -rf /env/share/man
-RUN rm -rf /env/share/terminfo
-RUN find /env -name '__pycache__' -type d -exec rm -rf '{}' '+'
-RUN find /env -name '*.a' -type f -exec rm -f '{}' '+'
+SHELL ["/bin/bash", "-l", "-i", "-c"]
+WORKDIR "$HOME"
+RUN git clone https://github.com/cclib/cclib.git
+WORKDIR "$HOME"/cclib
+COPY test.bash .
+RUN ./test.bash
+WORKDIR "$HOME"

--- a/py39/environment.yml
+++ b/py39/environment.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - cython  # only needed for pyquante2
   - h5py=2.10
   - openbabel
   - pip

--- a/py39/test.bash
+++ b/py39/test.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S bash --login
+
+set -euo pipefail
+set -x
+
+bash ./.github/scripts/run_pytest.bash
+bash ./.github/scripts/run_pytest_methods.bash
+
+set +x


### PR DESCRIPTION
Closes #5 #6 #7 

Only reason 3.11 doesn't build is because Psi4 doesn't exist for it yet and we can't skip right now.

Still missing a `docker run ...` in this repo's CI to make sure the GHA interface is working.