### PR TITLE
Pin pyscf and pydantic dependencies

### DIFF
--- a/py310/environment.yml
+++ b/py310/environment.yml
@@ -13,5 +13,7 @@ dependencies:
   - pytest-shutil
   - python=3.10
   - pip:
-      - pyscf
+      - pyscf<2.3
       - qc-iodata
+  # https://github.com/MolSSI/QCElemental/issues/312
+  - pydantic<2

--- a/py38/environment.yml
+++ b/py38/environment.yml
@@ -13,5 +13,7 @@ dependencies:
   - pytest-shutil
   - python=3.8
   - pip:
-      - pyscf
+      - pyscf<2.3
       - qc-iodata
+  # https://github.com/MolSSI/QCElemental/issues/312
+  - pydantic<2

--- a/py39/environment.yml
+++ b/py39/environment.yml
@@ -13,5 +13,7 @@ dependencies:
   - pytest-shutil
   - python=3.9
   - pip:
-      - pyscf
+      - pyscf<2.3
       - qc-iodata
+  # https://github.com/MolSSI/QCElemental/issues/312
+  - pydantic<2


### PR DESCRIPTION
- pyscf < 2.3 in order to keep bridge test passing
- pydantic < 2 because of https://github.com/MolSSI/QCElemental/issues/312
  - adding qcelemental >= 0.26 instead wasn't working