### PR TITLE
Remove openbabel from conda environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,7 @@ RUN mamba shell init
 RUN echo "mamba activate cclib" >> "$HOME"/.bashrc && \
     git clone https://github.com/cclib/cclib.git
 WORKDIR "$HOME"/cclib
-# Installing the Open Babel Python package only works when it is able to link
-# against system-installed Open Babel compiled libraries.  The conda package
-# provides both.
-RUN sed -i '/openbabel/d' pyproject.toml && \
-    pip-compile --all-extras pyproject.toml && \
+RUN pip-compile --all-extras pyproject.toml && \
     python -m pip install --no-cache-dir -r requirements.txt && \
     mv requirements.txt $HOME && \
     if [ -f requirements-bridges.txt ]; then python -m pip install --no-cache-dir -r requirements-bridges.txt; fi && \

--- a/py310/environment.yml
+++ b/py310/environment.yml
@@ -5,7 +5,6 @@ dependencies:
   - cython  # only needed for pyquante2
   - h5py
   - libint=2.9.0=*_4
-  - openbabel
   - pip
   - pip-tools
   - psi4

--- a/py311/environment.yml
+++ b/py311/environment.yml
@@ -5,7 +5,6 @@ dependencies:
   - cython  # only needed for pyquante2
   - h5py
   - libint=2.9.0=*_4
-  - openbabel
   - pip
   - pip-tools
   - psi4

--- a/py312/environment.yml
+++ b/py312/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - cython  # only needed for pyquante2
   - h5py
   - libint=2.9.0=*_4
-  - openbabel
   - pip
   - pip-tools
   - psi4

--- a/py37/environment.yml
+++ b/py37/environment.yml
@@ -182,6 +182,9 @@ dependencies:
   - numpy=1.21.3=py37h31617e3_0
   - oauth2client=4.1.3=py_0
   - olefile=0.46=pyh9f0ad1d_1
+  # Intentionally left here even though the full wheel is now installed via
+  # pyproject.toml for consistency with the rest of the concretized conda
+  # packages
   - openbabel=3.1.1=py37h6aa62a1_2
   - openjpeg=2.4.0=hb52868f_1
   - openssl=1.1.1l=h7f98852_0

--- a/py38/environment.yml
+++ b/py38/environment.yml
@@ -5,6 +5,9 @@ dependencies:
   - cython  # only needed for pyquante2
   - h5py=3.1
   - libint=2.9.0=*_4
+  # Wheels aren't built for this Python version.  The main repo CI hackily
+  # replaces this with `openbabel-wheel` which we avoid here for cleanliness
+  # reasons and the official conda package does work for this Python version.
   - openbabel
   - pip
   - pip-tools<7.5.3

--- a/py39/environment.yml
+++ b/py39/environment.yml
@@ -5,6 +5,9 @@ dependencies:
   - cython  # only needed for pyquante2
   - h5py=3.1
   - libint=2.9.0=*_4
+  # Wheels aren't built for this Python version.  The main repo CI hackily
+  # replaces this with `openbabel-wheel` which we avoid here for cleanliness
+  # reasons and the official conda package does work for this Python version.
   - openbabel
   - pip
   - pip-tools


### PR DESCRIPTION
https://github.com/cclib/cclib/pull/1729 introduced https://pypi.org/project/openbabel-wheel/ as a bridge dependency in pyproject.toml, so
- it doesn't need to be a conda package anymore
- there doesn't need to be a pyproject.toml workaround